### PR TITLE
Assign Ratings to the right manager

### DIFF
--- a/src/controllers/ratingController.js
+++ b/src/controllers/ratingController.js
@@ -2,99 +2,95 @@ import Response from '../helpers/response';
 import RatingService from '../services/ratingService';
 import UserServices from '../services/userService';
 
-import { computeAverage } from "../helpers/index";
+import { computeAverage } from '../helpers/index';
+
 class RatingController {
+  async createRatings(req, res, next) {
+    console.log('ratingggggg');
+    try {
+      // Creates Ratings
+      const createdRating = await RatingService.createRating(req.body);
+      const { trainee } = createdRating;
 
-    async createRatings(req, res, next) {
-        console.log("ratingggggg")
-        try {
-            //Creates Ratings
-            let createdRating = await RatingService.createRating(req.body);
-            const { trainee } = createdRating;
+      console.log('Step 1 User', trainee);
 
-            console.log("Step 1 User", trainee)
+      // Re-compute average rating
+      const { id } = req.user;
+      RatingService.computeAverage(trainee, id);
 
-
-            //Re-compute average rating
-            RatingService.computeAverage(trainee);
-
-            return Response.customResponse(res, 201, 'Rating created', createdRating);
-
-        } catch (error) {
-            return next(error);
-        }
+      return Response.customResponse(res, 201, 'Rating created', createdRating);
+    } catch (error) {
+      return next(error);
     }
+  }
 
-    async getAllRatings(req, res, next) {
-        try {
-            //Get All ratings from average_rating table
-            const ratings = await RatingService.getRatings();
-            
-            return Response.customResponse(res, 200, 'Ratings retrieved successfully', ratings)
-        } catch (error) {
-            return next(error);
-        }
+  async getAllRatings(req, res, next) {
+    try {
+      // Get All ratings from average_rating table
+      const ratings = await RatingService.getRatings();
+
+      return Response.customResponse(res, 200, 'Ratings retrieved successfully', ratings);
+    } catch (error) {
+      return next(error);
     }
+  }
 
-    async getAllEngineerRatings(req, res, next) {
-        try {
-            //Get All ratings from average_rating table
-            const ratings = await RatingService.getAverage({});
+  async getAllEngineerRatings(req, res, next) {
+    try {
+      // Get All ratings from average_rating table
+      const ratings = await RatingService.getAverage({});
 
-           // console.log("ratings===>", ratings)
+      // console.log("ratings===>", ratings)
 
-            return Response.customResponse(res, 200, 'Ratings retrieved successfully', ratings)
-        } catch (error) {
-            return next(error);
-        }
+      return Response.customResponse(res, 200, 'Ratings retrieved successfully', ratings);
+    } catch (error) {
+      return next(error);
     }
+  }
 
-    async getEngineerRating(req, res, next) {
-        console.log("fetching .... ratings..")
-        try {
-            const id = req.params.id
+  async getEngineerRating(req, res, next) {
+    console.log('fetching .... ratings..');
+    try {
+      const { id } = req.params;
 
-            //Check if Correct User Id Passed 
-            let user = await UserServices.findOneUser({id});
+      // Check if Correct User Id Passed
+      const user = await UserServices.findOneUser({ id });
 
-            console.log("user fetched", user)
+      console.log('user fetched', user);
 
-            if(!user || user.role !== 'Trainee') return Response.notFoundError(res, 'Invalid engineer Id passed')
-            //Get All ratings 
-            let ratings = await RatingService.getRatings({ trainee: id });
+      if (!user || user.role !== 'Trainee') return Response.notFoundError(res, 'Invalid engineer Id passed');
+      // Get All ratings
+      const ratings = await RatingService.getRatings({ trainee: id });
 
-            //Get Average rating from average_rating Table
-            let average = await RatingService.getAverage({ trainee: id });
+      // Get Average rating from average_rating Table
+      const average = await RatingService.getAverage({ trainee: id });
 
-            return Response.customResponse(res, 200, 'Ratings retrieved successfully', { average, ratings });
-
-        } catch (error) {
-            return next(error);
-        }
-
+      return Response.customResponse(res, 200, 'Ratings retrieved successfully', { average, ratings });
+    } catch (error) {
+      return next(error);
     }
+  }
 
-    async updateRating(req, res, next) {
-        try {
-            //Get Rating by Id 
-            const rating = await RatingService.getRatings({ id: req.params.id });
+  async updateRating(req, res, next) {
+    try {
+      // Get Rating by Id
+      const rating = await RatingService.getRatings({ id: req.params.id });
 
-            if (rating.length === 0) return Response.notFoundError(res, 'Invalid rating Id used');
+      if (rating.length === 0) return Response.notFoundError(res, 'Invalid rating Id used');
 
-            let updatedRating = await RatingService.updateRating({id: req.params.id}, req.body);
+      const updatedRating = await RatingService.updateRating({ id: req.params.id }, req.body);
 
-            const { user } = rating[0].dataValues;
+      const { user } = rating[0].dataValues;
 
-            //Re-compute average rating
-            RatingService.computeAverage(user);
+      // Re-compute average rating
+      const { id } = req.user;
+      RatingService.computeAverage(user, id);
 
-            return Response.customResponse(res, 200, 'Rating updated', updatedRating);
-        } catch (error) {
-            return next(error);
-        }
-
+      return Response.customResponse(res, 200, 'Rating updated', updatedRating);
+    } catch (error) {
+      return next(error);
     }
+  }
 }
-
 
 export default new RatingController();

--- a/src/services/ratingService.js
+++ b/src/services/ratingService.js
@@ -1,118 +1,110 @@
-import database from '../database/models';
 import sequelize from 'sequelize';
-import { computeAverage } from "../helpers/index";
+import database from '../database/models';
+import { computeAverage } from '../helpers/index';
 
-const  Rating   = database.rating;
+const Rating = database.rating;
 
-const AverageRatings   = database.averageRating;
+const AverageRatings = database.averageRating;
 const User = database.user;
 class RatingService {
-    static async createRating(rating){
-        try{
-            let ratings = await Rating.create(rating);
-            return ratings
-
-        }catch(error){
-            console.log("error",rating)
-            throw error;
-        }
+  static async createRating(rating) {
+    try {
+      const ratings = await Rating.create(rating);
+      return ratings;
+    } catch (error) {
+      console.log('error', rating);
+      throw error;
     }
+  }
 
-    static async getRatings(param){
-        console.log("param", param)
-        try{
-            let ratings = await Rating.findAll({where: param});
-            return ratings;
-
-        }catch(error){
-            throw error;
-        }
+  static async getRatings(param) {
+    console.log('param', param);
+    try {
+      const ratings = await Rating.findAll({ where: param });
+      return ratings;
+    } catch (error) {
+      throw error;
     }
+  }
 
-    static async updateRating(id, rating){
-        try{
-            let updatedRating = await Rating.update(rating, {
-                returning: true,
-                where: id
-            })
+  static async updateRating(id, rating) {
+    try {
+      const updatedRating = await Rating.update(rating, {
+        returning: true,
+        where: id,
+      });
 
-            return updatedRating;
-        }catch(error){
-            throw error;
-        }
+      return updatedRating;
+    } catch (error) {
+      throw error;
     }
+  }
 
-    static async computeAverage(trainee){
-        try{
-            console.log("RatingService 1")
-            let allRatings = await RatingService.getRatings({ trainee });
-            console.log("RatingService 2")
+  static async computeAverage(trainee, submitter) {
+    try {
+      console.log('RatingService 1');
+      const allRatings = await RatingService.getRatings({ trainee });
+      console.log('RatingService 2');
 
+      // Compute Average of all ratings of a user
+      const average_rating = computeAverage(allRatings);
 
-            //Compute Average of all ratings of a user
-            let average_rating = computeAverage(allRatings);
+      console.log('average_rating', average_rating);
 
-            console.log("average_rating", average_rating)
-
-            //Update the average ratings Table
-            await RatingService.updateAverage({trainee},average_rating);
-            console.log("Done average_rating")
-
-        }catch(error){
-            throw error;
-        }
+      // Update the average ratings Table
+      await RatingService.updateAverage({ trainee }, submitter, average_rating);
+      console.log('Done average_rating');
+    } catch (error) {
+      throw error;
     }
+  }
 
-    static async getAverage(param){
-        console.log("param ",param)
-        try{
-            let average = await AverageRatings.findAll({
-                where: param,
-                include:[
-                    {
-                        model: User,
-                        attributes:['id','firstName','lastName','email']}
+  static async getAverage(param) {
+    console.log('param ', param);
+    try {
+      const average = await AverageRatings.findAll({
+        where: param,
+        include: [
+          {
+            model: User,
+            attributes: ['id', 'firstName', 'lastName', 'email'],
+          },
 
-                ]
-            });
+        ],
+      });
 
-           console.log("average", average)
-            return average;
-
-        }catch(error){
-            console.log(error);
-            throw error;
-        }
+      console.log('average', average);
+      return average;
+    } catch (error) {
+      console.log(error);
+      throw error;
     }
+  }
 
-    static async updateAverage(trainee, rating){
-        console.log("trainee   ====>", trainee)
-        try{
-            let found_average = await AverageRatings.findAll({where: trainee});
+  static async updateAverage(trainee, submitter, rating) {
+    console.log('trainee   ====>', trainee);
+    try {
+      const found_average = await AverageRatings.findAll({ where: trainee });
 
-            if(found_average.length != 0){
-                let average = await AverageRatings.update(rating, {
-                    returning: true,
-                    where: trainee
-                });
+      if (found_average.length != 0) {
+        const average = await AverageRatings.update(rating, {
+          returning: true,
+          where: trainee,
+        });
 
-                return average;
-            }
+        return average;
+      }
 
-            rating.trainee = trainee.trainee;
-            console.log("rating   ====>", rating)
+      rating.trainee = trainee.trainee;
 
+      rating.submitter = submitter;
+      const average = await AverageRatings.create(rating);
 
-            rating.submitter = 1; //Making Super LF default submitter for now
-            let average =  await AverageRatings.create(rating);
-
-            return average;
-
-        }catch(error){
-            throw error;
-        }
+      return average;
+    } catch (error) {
+      throw error;
     }
+  }
 }
-
 
 export default RatingService;


### PR DESCRIPTION
#### What does this PR do?
- Assign Ratings to the right manager
- 
#### Description of Task to be completed?
- All ratings are getting the submitter/manager of 1 by default, in the backed we should associate every rating with the right manager
#### How should this be manually tested?

- clone this repo if you didn't check out  to `ft-assign-ratingd-to-manager` branch.
- install all dependencies and start the app
- Sign in  as a manager
- use this endpoint to rate  an engineer  `http://localhost:3000/api/v1/ratings/rate`
![rate-engineer](https://user-images.githubusercontent.com/26524106/127295478-8c26a484-d044-4559-80b1-4441a1990e4e.png)

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[]()
#### Screenshots (if appropriate)
N/A
#### Questions:
N/A